### PR TITLE
Readme: typo in `import` and add template example

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,17 @@ Usage
 ------------------------------------------------------------------------------
 
 ```js
-import { createComponent } from 'ember-functional-components';
+import { createComponent } from 'ember-functional-component';
 
 export default createComponent(props => {
   return {
     fullName: `${props.first} ${props.last}`,
   }
 })
+```
+
+```handlebars
+{{this.fullName}}
 ```
 
 The function you provide will be called whenever the incoming arguments change.


### PR DESCRIPTION
This PR just fixes the example's `import` (it included an extra 's'). This also adds a quick accompanying template example.